### PR TITLE
Use standard province/territory names and abbreviations

### DIFF
--- a/join.lib.js
+++ b/join.lib.js
@@ -39,7 +39,7 @@ var JoinForm = function () {
    	this.fields["password"].isPassword = ["Password must be 4 or more letters and 2 or more numbers"];
     this.fields["state"].isState = "State is not valid.";
     this.fields["zip"].isZip = "ZIP Code is not valid.";
-    this.fields["province"].isProvince = "Province is not valid.";
+    this.fields["province"].isProvince = "Province/Territory is not valid.";
     this.fields["postal"].isPostal = "Postal Code is not valid.";
     this.fields["tele"].isPhone = "Phone number is not valid.";
     this.success = "You have successfully joined. We're happy to have you as a member."
@@ -87,12 +87,11 @@ JoinForm.prototype.isCountry = function(country){
 }
 
 JoinForm.prototype.isState = function (text) {
-    var states = new Array(
-        "AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DE", "DC", "FL",
+    var states = ["AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DE", "DC", "FL",
         "GA", "HI", "ID", "IL", "IN", "IA", "KS", "KY", "LA", "ME",
         "MD", "MA", "MI", "MN", "MS", "MO", "MT", "NE", "NV", "NH",
         "NJ", "NM", "NY", "NC", "ND", "OH", "OK", "OR", "PA", "RI",
-        "SC", "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI", "WY");
+        "SC", "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI", "WY"];
     for( var i in states ) {
         if ( text == states[i] ) {
             return true;
@@ -102,9 +101,7 @@ JoinForm.prototype.isState = function (text) {
 }
 
 JoinForm.prototype.isProvince = function (text) {
-    var provinces = new Array(
-        "BC", "AB", "SK", "MB", "ON", "QB", "PE", "NS", "NF", "NB",
-        "YK", "NV", "NW" );
+    var provinces = ["AB", "BC", "MB", "NB", "NL", "NS", "NU", "NT", "ON", "PE", "QC", "SK", "YT"];
     for( var i in provinces ) {
         if ( text == provinces[i] ) {
             return true;

--- a/landmarks.html
+++ b/landmarks.html
@@ -168,23 +168,23 @@
     </dd>
 
     <dt class="prov_block">
-    <label for="province">Province:</label>
+    <label for="province">Province/Territory:</label>
     </dt>
     <dd class="prov_block">
                     <select name="province" id="province" class="input">
-                        <option value="BC">BC</option>
-                        <option value="AB">AB</option>
-                        <option value="SK">SK</option>
-                        <option value="MB">MB</option>
-                        <option value="ON">ON</option>
-                        <option value="QC">QC</option>
-                        <option value="PE">PE</option>
-                        <option value="BC">NS</option>
-                        <option value="NB">NB</option>
-                        <option value="NF">NFLD</option>
-                        <option value="YK">Yukon</option>
-                        <option value="NV">Nunavut</option>
-                        <option value="NW">NWT</option>
+                        <option value="AB">Alberta</option>
+                        <option value="BC">British Columbia</option>
+                        <option value="MB">Manitoba</option>
+                        <option value="NB">New Brunswick</option>
+                        <option value="NL">Newfoundland and Labrador</option>
+                        <option value="NS">Nova Scotia</option>
+                        <option value="NU">Nunavut</option>
+                        <option value="NT">Northwest Territories</option>
+                        <option value="ON">Ontario</option>
+                        <option value="PE">Prince Edward Island</option>
+                        <option value="QC">Quebec</option>
+                        <option value="SK">Saskatchewan</option>
+                        <option value="YT">Yukon</option>
                     </select>
                     <span id="province_error">&nbsp;</span>
     </dd>
@@ -197,7 +197,7 @@
     </dd>
 
 <dt>
-    <label for="tele">Telephone</label>: 
+    <label for="tele">Telephone</label>:
 </dt>
 <dd>
     <input type="text" id="tele" name="telephone"  class="input" value="" >


### PR DESCRIPTION
Use standard province/territory names and abbreviations from [StatCan's Abbreviations and codes for provinces and territories](https://www12.statcan.gc.ca/census-recensement/2011/ref/dict/table-tableau/table-tableau-8-eng.cfm).

Also rename 'province' to 'province/territory'.